### PR TITLE
Fix LinkedIn 404

### DIFF
--- a/tree/tree-me.html
+++ b/tree/tree-me.html
@@ -15,7 +15,7 @@
 			  <a href="#">professional</a>
 			  <ul>
 			    <li id="linkedIn">
-                  <a href="http://www.linkedin.com/pub/dan-kefford/a/b17/748">LinkedIn</a>
+                  <a href="https://www.linkedin.com/pub/danielle-kefford/a/b17/748">LinkedIn</a>
                 </li>
 			    <li id="github">
                   <a href="https://github.com/quephird">github</a>


### PR DESCRIPTION
Fix LinkedIn 404.
Alt fix would be updating URL to `https://www.linkedin.com/in/danielle-kefford-748b17a` , but I like the `pub` in the URL path.